### PR TITLE
Allow multiline lambda expressions in python

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = false
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+max_line_length = 80
+
+[{package.json,*.yml}]
+indent_style = space
+indent_size = 2
+
+[{makefile, Makefile}]
+indent_style = tab
+indent_size = 4

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,3 +1,3 @@
 [style]
 based_on_style = pep8
-
+ALLOW_MULTILINE_LAMBDAS = True


### PR DESCRIPTION
RoboJackets/robocup-software#1001 has a bunch of super long lambdas and they're reaching ~200 ~lines~chars. I would like to have these lambdas on multiple lines.

https://github.com/RoboJackets/robocup-software/blob/6a812c03b5951bd79f75f3f95603a7182408a9c1/soccer/gameplay/plays/restarts/their_kickoff.py#L79

This also ends up clearing most of my issues with https://github.com/RoboJackets/robocup-software/issues/802 on the python side...

Thoughts?

@joshhting, @chachmu. @RoboJackets/robocup-software 

Since no one uses python but robocup, I don't think I need to `@` them, but any feedback is appreciated.